### PR TITLE
Made NPM Script Paths Shorter

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Arctic Web Site",
   "main": "",
   "scripts": {
-    "local": "./node_modules/.bin/harp server src & ./node_modules/.bin/browser-sync start -b 'google-chrome' --proxy localhost:9000 --files 'src'",
-    "compile": "./node_modules/.bin/harp compile src dist"
+    "local": "harp server src & browser-sync start -b 'google-chrome' --proxy localhost:9000 --files 'src'",
+    "compile": "harp compile src dist"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
You don't need to add `./node_modules/.bin/` when you write NPM scripts as when it runs them it does so with a `PATH` that includes `./node_modules/.bin/`
